### PR TITLE
4-3 New tricky case for test3.ml

### DIFF
--- a/hw4/test3.ml
+++ b/hw4/test3.ml
@@ -62,6 +62,7 @@ module TestEx3: TestEx =
       ; FAIL (Branch (Guide ("c", Branch (Branch (Guide ("a", Branch (End (NameBox "a"), End (NameBox "b"))), Branch (End (NameBox "b"), End (NameBox "a"))), End (NameBox "c"))), End StarBox))
       ; GETREADY (Branch (End (NameBox "z"), Guide ("x", Branch (Guide ("y", Branch (End (NameBox "x"), End (NameBox "y"))), End StarBox))), [Bar; (Node (Bar, Bar)); (Node (Node (Node (Bar, Bar), Bar), Bar))])
       ; GETREADY (Branch (Branch (Branch (Guide ("b", Guide ("a", Branch (End (NameBox "a"), End (NameBox "b")))), End (NameBox "c")), Guide ("d", End (NameBox "d"))), End (NameBox "e")), [Bar; Node (Bar, Bar); Node (Node (Bar, Bar), Node (Bar, Bar))])
+      ; GETREADY (Branch(Branch(Branch(End(NameBox "R"), End(NameBox "Z")), End(NameBox "Y")), Branch(End(NameBox "X"), Branch(Branch(Branch(End(NameBox "M"), Guide("Q", End(NameBox "Q"))),End(NameBox "P")), End(NameBox "L")))), [Bar; Node(Bar, Bar); Node(Node(Bar, Bar), Node(Bar, Node(Bar, Bar)))] )
       ]
 
     let string_of_treasure t =


### PR DESCRIPTION
보물섬 문제를 풀 때, 총 필요한 열쇠 길이의 합을 줄이는 것이 목표입니다.

let map = Branch(Branch(Branch(End(NameBox "R"), End(NameBox "Z")), End(NameBox "Y")), Branch(End(NameBox "X"), Branch(Branch(Branch(End(NameBox "M"), Guide("Q", End(NameBox "Q"))),End(NameBox "P")), End(NameBox "L"))))

여기에서 만약 Z = - 로 두면, 다음과 같은 열쇠가 필요합니다.
Z: -
Y: -
Q: -
P: -
L: -
M: ((-,-),(-,(-,-)))
X: (-,-)
R: (-,(-,(-,-)))

그러나 Z = (-,-) 이면 R이 필요로 하는 키가 (Z, (-,(-,-))) 이기 때문에 ((-,-),(-,(-,-))) 이 됩니다. 이는 M이 필요로 하는 키와 동일합니다.

따라서 세 가지의 키만 필요하게 됩니다.
Z: (-,-)
Y: -
Q: -
P: -
L: -
M: ((-,-),(-,(-,-)))
X: (-,-)
R: ((-,-),(-,(-,-)))

이 경우를 테스트하지 않는 것 같아서 추가합니다